### PR TITLE
Added ASE CFP & Amaru to the Tooling page

### DIFF
--- a/events/ase2024.md
+++ b/events/ase2024.md
@@ -1,0 +1,60 @@
+---
+title: "Special Issue on GI in ASE journal"
+chairs:
+- name: Oliver Krauss
+  desc: "%%NAME%% received his doctorate in 2022 in Pattern Mining and Genetic Improvement in Compilers and Interpeters.
+  His research focuses on mining patterns in software, as well as data, to improve runtime performance and energy consumption.
+  He maintains several open source frameworks, such as <a href='https://amaru.dev'>Amaru</a>)."
+- name: Vesna Nowack
+  desc: "%%NAME%%. Since she gained her PhD in Software Engineering in 2016 from the Universitat Politecnica de Catalunya in Barcelona, she has conducted research in supercomputing (Spain) and taught robotics in Germany. Her recent research has been on APR in the UK, including 12 months with Bloomberg (London) published this summer as “On the Introduction of Automatic Program Repair in Bloomberg” by IEEE Software. She is now a Senior Research Assistant at Lancaster University where she continues her work on using GI to automatically fix bugs."
+- name: Justyna Petke
+  desc: "%%NAME%% is a Principal Research Fellow and Proleptic Associate Professor, conducting research in genetic improvement.
+  She is at the Centre for Research on Evolution, Search and Testing at University College London.
+  Her work on genetic improvement was awarded a Silver (GECCO 2014) and a Gold ’Humie’ (GECCO 2016) and an ACM SIGSOFT Distinguished Paper Award at ISSTA 2015.
+  She was the PC co-Chair for the International Symposium on Search-Based Software Engineering in 2017.
+  She also organised 9 Genetic Improvement Workshops.
+  She currently serves on the editorial board of the Journal of Systems and Software, Empirical Software Engineering, Genetic Programming and Evolvable Machines, Automated Software Enigineering and Engineering Applications of Artificial Intelligence journals."
+---
+
+# Special Issue on GI in the ASE journal
+
+## Overview
+
+Authors of accepted papers are invited to submit their extended work to the Special Issue on Genetic Improvement to be published in the [Automated Software Engineering](https://www.springer.com/journal/10515) journal. 
+
+Genetic Improvement is the application of evolutionary and search-based optimisation methods to the improvement of existing software. It has been used to improve both software functional properties, such as fixing bug or performing automated code transplantation, and software non-functional properties, such as minimising execution time, memory usage, or energy consumption.
+
+We invite submissions that discuss recent developments in all areas of research on, and applications of, Genetic Improvement. 
+Topics of interest include both the theory and practice of Genetic Improvement. Applications of GI include, but are not limited to:
+- Improve runtime efficiency
+- Decrease memory consumption
+- Decrease energy consumption
+- Transplant new functionality
+- Specialise software
+- Generate multiple versions of software
+- Improve low level or binary code
+- Use of AI/large language models with GI
+- Repair bugs
+- GI techniques in industrial settings
+
+## Key Dates and Submission Details
+
+Submission: To be Announced
+
+Submissions should follow the usual [ASE submission guidelines](https://www.springer.com/journal/10515/submission-guidelines).
+
+The Submission link will be anounced on the ASE journal's website.
+
+## <a name="chairs"></a> Organisers
+
+{% for chair in page.chairs %}{% assign match = nil %}{% for p in site.data.people %}{% if p.name == chair.name %}{% assign match = p %}{% break %}{% else %}{% for aka in p.aka %}{% if aka == chair.name %}{% assign match = p %}{% break %}{% endif %}{% endfor %}{% endif %}{% endfor %}
+<figure class="figure float-right" style="margin: auto 0.5em;">
+  <img class="figure-img rounded img-thumbnail" style="max-width: 200px; max-height: 160px" src="{{ match.img | relative_url }}" onerror="this.onerror=null; this.src='{{ "/profile_images/blank.jpg" | relative_url }}'">
+  <figcaption class="figure-caption text-right">{{ chair.name }}</figcaption>
+</figure>
+
+{% capture chair_name %}<b>{% if match.homepage %}<a href="{{ match.homepage }}">{{ match.name }}</a>{% else %}{{ chair.name }}{% endif %}</b>{% endcapture %}
+<p class="clearfix">
+  {{ chair.desc | replace: '%%NAME%%', chair_name }}
+</p>
+{% endfor %}

--- a/events/icse2024.md
+++ b/events/icse2024.md
@@ -126,6 +126,10 @@ These papers will be reviewed in a double-blind manner.
 All accepted papers must be presented at the workshop.
 
 
+### Special Issue on GI in the ASE journal
+
+Authors of accepted papers are invited to submit an extended version of their papers to [ASE Journal's second Special Issue on Genetic Improvement](https://geneticimprovementofsoftware.com/events/ase2024).
+
 ## <a name="chairs"></a> Workshop Chairs
 
 {% for chair in page.chairs %}{% assign match = nil %}{% for p in site.data.people %}{% if p.name == chair.name %}{% assign match = p %}{% break %}{% else %}{% for aka in p.aka %}{% if aka == chair.name %}{% assign match = p %}{% break %}{% endif %}{% endfor %}{% endif %}{% endfor %}

--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ We as a community run a workshop and frequent [events]({{ "/events/gi" | relativ
 
 
 ## News
-* The [13th International Workshop on Genetic Improvement](events/icse2024) will take place at [ICSE 2024](https://conf.researchr.org/home/icse-2024). Prof. Shin Yoo will give the keynote talk.
+* The [13th International Workshop on Genetic Improvement](events/icse2024) will take place at [ICSE 2024](https://conf.researchr.org/home/icse-2024). Prof. Shin Yoo will give the keynote talk. Authors of accepted papers are invited to submit an extended version of their papers to [ASE Journal's second Special Issue on Genetic Improvement](https://geneticimprovementofsoftware.com/events/ase2024).
 * The CREST Centre at UCL is inviting attendees for 2 GI-related workshops, on Aug 3rd-4th and Sep 18th-19th. Please register for [COW64 and COW65](https://www.ucl.ac.uk/crest/crest-open-workshops).
 * The next tutorial on genetic improvement will be given at [GECCO 2023](https://gecco-2023.sigevo.org/Tutorials#id_Genetic%20Improvement:%20Taking%20real-world%20source%20code%20and%20improving%20it%20using%20computational%20search%20methods) by Alexander Brownlee, Saemundur Haraldsson, and John Woodward.
 * The [12th International Workshop on Genetic Improvement](events/icse2023) took place at [ICSE 2023](https://conf.researchr.org/home/icse-2023). Prof. Myra Cohen and Dr. Sebastian Baltes gave keynote talks. Authors of accepted papers are invited to submit an extended version of their papers to [ASE's Special Issue on Genetic Improvement](https://link.springer.com/collections/gabebegheh).

--- a/use/tools.md
+++ b/use/tools.md
@@ -29,6 +29,8 @@ Here are a few other examples of existing work:
 </a>
 - <a href="https://github.com/squaresLab/genprog4java/">JarFly: Java Repair Framework</a>
 - <a href="https://github.com/prapr/prapr">PraPR: Practical Program Repair via Bytecode Mutation</a>
+- <a href="https://github.com/oliver-krauss/amaru">Amaru - A framework for Genetic Improvement in Graal VM  with support for Mining Patterns from GI Experiments</a>
+
 
 Other frameworks and libraries identified at the <a href="https://www.dagstuhl.de/en/program/calendar/semhp/?semnr=18052">Dagstuhl Seminar on Genetic Improvement of Software</a> held in January 2018:
 - <a href="http://crest.cs.ucl.ac.uk/autotransplantation/downloads/muScalpel.zip">MuScalpel: automated software transplantation</a>


### PR DESCRIPTION
    Added the link to the front page
    A section to the ICSE2024 Event page
    A new ASE2024 Special Issue page which is mostly a copy-paste from ASE2023 with "to be announced", and the CFP aligned with the workshop call.
   Added a link to the Amaru Tool in the Tools page