### PR TITLE
Fixed outdated affiliations

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -36,7 +36,7 @@
 
 - name: Nadia Alshahwan
   show: yes
-  affil: Facebook London, UK
+  affil: Meta, UK
   homepage: https://www.linkedin.com/in/nadiaalshahwan
   dblp: https://dblp.org/pid/98/6159.html
   scholar: https://scholar.google.com/citations?user=TG8-wssAAAAJ
@@ -288,7 +288,7 @@
 
 - name: Yue Jia
   show: yes
-  affil: Facebook, UK
+  affil: Meta, UK
   homepage: https://uk.linkedin.com/in/yue-jia-3326b796
   dblp: https://dblp.org/pid/44/4993-1.html
   scholar: https://scholar.google.co.uk/citations?user=DG4Q08UAAAAJ
@@ -614,7 +614,7 @@
 
 - name: Markus Wagner
   show: yes
-  affil: University of Adelaide, Australia
+  affil: Monash University, Australia
   homepage: http://acrocon.com/~wagner/
   dblp: https://dblp.uni-trier.de/pid/94/7030-7.html
   scholar: https://scholar.google.com/citations?user=9cbh6PoAAAAJ


### PR DESCRIPTION
When creating the Frontmatter for the GI workshop I noticed a few outdated affiliations.