### PR TITLE
Fix typo in icse2024.md

### DIFF
--- a/events/icse2024.md
+++ b/events/icse2024.md
@@ -168,7 +168,7 @@ for the Genetic Improvement of Software* &mdash; **Benjamin Craine**, Penn Rainf
     - [15:30](https://time.is/1530_16_April_2024_in_Lisbon): Break &amp; Afternoon tea  (30 minutes)
 - Tuesday, April 16, 16:00--17:15 (75 mins)
     - [16:00](https://time.is/1600_16_April_2024_in_Lisbon): *On Reducing Network Usage with Genetic Improvement* &mdash; James Callan, Bill Langdon and **Justyna Petke** (20+10 mins)
-    - [16:30](https://time.is/1630_16_April_2024_in_Lisbon): **Discussion**, **Awards**, and **Closing** (75 min)
+    - [16:30](https://time.is/1630_16_April_2024_in_Lisbon): **Discussion**, **Awards**, and **Closing** (45 min)
 
 
 ## <a name="CFP"></a> Call For Submissions [[pdf]({{ "/paper_pdfs/gi2024icse/call_for_papers.pdf" | relative_url }})]


### PR DESCRIPTION
Fix the duration of the closing session (75 -> 45 min)